### PR TITLE
fix(timeoutHeight): removing ZeroHeight() and bumping sdk version, fixing rly.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/interchainberlin/ica
 go 1.15
 
 require (
-	github.com/cosmos/cosmos-sdk v0.42.0
+	github.com/cosmos/cosmos-sdk v0.42.3
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/cosmos-sdk v0.42.0 h1:oQ+rUTYZ5gUq8/YEW83NosCJ3+41iA/3/wZ3pfEIYH8=
-github.com/cosmos/cosmos-sdk v0.42.0/go.mod h1:xiLp1G8mumj82S5KLJGCAyeAlD+7VNomg/aRSJV12yk=
+github.com/cosmos/cosmos-sdk v0.42.3 h1:VFYq7spDBBIlygAxwcI79Xh2JuIrG1ZCPKpvqKghIZs=
+github.com/cosmos/cosmos-sdk v0.42.3/go.mod h1:xiLp1G8mumj82S5KLJGCAyeAlD+7VNomg/aRSJV12yk=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=

--- a/network/relayer/interchain-acc-config/rly.sh
+++ b/network/relayer/interchain-acc-config/rly.sh
@@ -30,7 +30,7 @@ $BINARY light init test-1 -f --home $CHAIN_DIR/$RELAYER_DIR
 $BINARY light init test-2 -f --home $CHAIN_DIR/$RELAYER_DIR
 
 echo "Linking both chains..."
-$BINARY tx path test1-account-test2 --home $CHAIN_DIR/$RELAYER_DIR
+$BINARY tx link test1-account-test2 --home $CHAIN_DIR/$RELAYER_DIR
 
 echo "Starting to listen relayer..."
 $BINARY start test1-account-test2 --home $CHAIN_DIR/$RELAYER_DIR

--- a/x/ibc-account/keeper/relay.go
+++ b/x/ibc-account/keeper/relay.go
@@ -40,8 +40,6 @@ func (k Keeper) TryRegisterIBCAccount(ctx sdk.Context, sourcePort, sourceChannel
 		Data: salt,
 	}
 
-	timeoutHeight := clienttypes.ZeroHeight()
-
 	// timeoutTimestamp is set to be a max number here so that we never recieve a timeout
 	// ics-27-1 uses ordered channels which can close upon recieving a timeout, which is an undesired effect
 	const timeoutTimestamp = ^uint64(0)
@@ -53,7 +51,7 @@ func (k Keeper) TryRegisterIBCAccount(ctx sdk.Context, sourcePort, sourceChannel
 		sourceChannel,
 		destinationPort,
 		destinationChannel,
-		timeoutHeight,
+		clienttypes.ZeroHeight(),
 		timeoutTimestamp,
 	)
 
@@ -128,8 +126,6 @@ func (k Keeper) createOutgoingPacket(
 		Data: txBytes,
 	}
 
-	timeoutHeight := clienttypes.ZeroHeight()
-
 	// timeoutTimestamp is set to be a max number here so that we never recieve a timeout
 	// ics-27-1 uses ordered channels which can close upon recieving a timeout, which is an undesired effect
 	const timeoutTimestamp = ^uint64(0)
@@ -141,7 +137,7 @@ func (k Keeper) createOutgoingPacket(
 		sourceChannel,
 		destinationPort,
 		destinationChannel,
-		timeoutHeight,
+		clienttypes.ZeroHeight(),
 		timeoutTimestamp,
 	)
 


### PR DESCRIPTION
Bumping the SDK version and using the most recent relayer commands in `rly.sh`. 

This PR depends on https://github.com/cosmos/relayer/pull/483